### PR TITLE
Fixed dealer cards after bust

### DIFF
--- a/blackjack_game.py
+++ b/blackjack_game.py
@@ -96,7 +96,7 @@ class BlackjackGame:
                 busted = False
         if busted:
             print(f"Bust")
-            self.dealer_last_hand = []
+            self.dealer_last_hand = self.dealer.get_cards()
             return
 
         # Play the dealer's hand


### PR DESCRIPTION
Previously after the player busts, the dealer would not reveal its hole card, which seems to be standard in blackjack. If it is being played without the dealer should still reveal its card it has a blackjack.